### PR TITLE
fixed multiply button which was returning null on into

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Calc :)</string>
-    <string name="x">X</string>
+    <string name="x">*</string>
     <string name="_0">0</string>
     <string name="modylo">%</string>
     <string name="dot">.</string>


### PR DESCRIPTION
When multiplying two numbers the into button was returning null the issue was occuring because instead of into(*) there was X that's why it was returning value as null.